### PR TITLE
Update to better accommodate a 2-part deployment-flow

### DIFF
--- a/SupportFiles/artifactory_db_properties.sh
+++ b/SupportFiles/artifactory_db_properties.sh
@@ -20,6 +20,7 @@ ARTIFACTORY_DBHOST="${ARTIFACTORY_DBHOST:-UNDEF}"
 ARTIFACTORY_DBPORT="${ARTIFACTORY_DBPORT:-5432}"
 ARTIFACTORY_RPM=jfrog-artifactory-pro
 ARTIFACTORY_LICKEY=${ARTIFACTORY_ETC}/artifactory.lic
+DBPROPERTIES="${ARTIFACTORY_ETC}/db.properties"
 SELSRC=${ARTIFACTORY_ETC}/mimetypes.xml
 
 ## Try not to let any prior stytem-hardening cause
@@ -73,6 +74,9 @@ function CreateDbProperties {
       mv "${DBPROPERTIES}" "${DBPROPERTIES}.BAK-${DATE}" || \
         err_exit "Failed to preserve existing '${DBPROPERTIES}' file"
    fi
+
+   # Locate example contents
+   SRCPGSQLCONF=$(rpm -ql ${ARTIFACTORY_RPM} | grep postgresql.properties)
 
    # Grab header-content from RPM's example file
    grep ^# "${SRCPGSQLCONF}" > "${DBPROPERTIES}" || \

--- a/SupportFiles/artifactory_ha-setup.sh
+++ b/SupportFiles/artifactory_ha-setup.sh
@@ -14,6 +14,14 @@ ISPRIMARY=${ARTIFACTORY_CL_PRIM:-true}
 HABUNDLE=${ARTIFACTORY_HABUNDLE:-UNDEF}
 HACONF="${ARTIFACTORY_ETC}/ha-node.properties"
 
+
+# Skip if not to be a part of a "cluster"
+if [[ ${ARTIFACTORY_CL_MMBR} = false ]]
+then
+   echo "Node not designated as cluster member. Exiting."
+   exit 0
+fi
+
 # Error-handler function
 function err_exit {
    logger -s -p kern.crit -t "${PROGNAME}" "Failed: ${1}"

--- a/Templates/make_artifactory_EC2-node.tmplt.json
+++ b/Templates/make_artifactory_EC2-node.tmplt.json
@@ -156,6 +156,7 @@
               "ArtifactoryArtifactBucket",
               "ArtifactoryLicenseUrl",
               "ArtifactoryHaBundleUrl",
+              "ArtifactoryIsHaMember",
               "ArtifactoryIsHaPrimary"
           ]
         },
@@ -217,6 +218,9 @@
          },
          "ArtifactoryHaBundleUrl": {
            "default" : "Node config bundle URL"
+         },
+         "ArtifactoryIsHaMember": {
+           "default" : "Is cluster member"
          },
          "ArtifactoryIsHaPrimary": {
            "default" : "Is cluster primary"
@@ -404,6 +408,15 @@
       "ConstraintDescription": "An LSB-compliant, slash-delimited directory-path.",
       "Default": "/var/opt/jfrog/artifactory",
       "Description": "The root installation location for the Artifactory application.",
+      "Type": "String"
+    },
+    "ArtifactoryIsHaMember": {
+      "Description": "Whether instance is a member of an HA cluster.",
+      "AllowedValues": [
+        "true",
+        "false"
+      ],
+      "Default": "true",
       "Type": "String"
     },
     "ArtifactoryIsHaPrimary": {
@@ -906,58 +919,61 @@
                 "runcmd:\n",
                 "  - |-\n",
                 "      # Artifactory global-envs\n",
-                "      export ARTIFACTORY_HOME=",
+                "      export ARTIFACTORY_HOME=\"",
                 {
                   "Ref": "ArtifactoryHome"
                 },
-                "\n",
-                "      export ARTIFACTORY_ETC=${ARTIFACTORY_HOME}/etc\n",
-                "      export ARTIFACTORY_LOGS=${ARTIFACTORY_HOME}/logs\n",
-                "      export ARTIFACTORY_VARS=${ARTIFACTORY_HOME}/etc/default\n",
-                "      export ARTIFACTORY_TOMCAT_HOME=${ARTIFACTORY_HOME}/tomcat\n",
-                "      export ARTIFACTORY_CL_PRIM=",
+                "\"\n",
+                "      export ARTIFACTORY_ETC=\"${ARTIFACTORY_HOME}/etc\"\n",
+                "      export ARTIFACTORY_LOGS=\"${ARTIFACTORY_HOME}/logs\"\n",
+                "      export ARTIFACTORY_VARS=\"${ARTIFACTORY_HOME}/etc/default\"\n",
+                "      export ARTIFACTORY_TOMCAT_HOME=\"${ARTIFACTORY_HOME}/tomcat\"\n",
+                "      export ARTIFACTORY_CL_MMBR=\"",
+                         { "Ref": "ArtifactoryIsHaMember" },
+                         "\"\n",
+                "      export ARTIFACTORY_CL_PRIM=\"",
                          { "Ref": "ArtifactoryIsHaPrimary" },
-                         "\n",
-                "      export ARTIFACTORY_HABUNDLE=",
+                         "\"\n",
+                "      export ARTIFACTORY_HABUNDLE=\"",
                          { "Ref": "ArtifactoryHaBundleUrl" },
-                         "\n",
-                "      export ARTIFACTORY_DBINST=",
+                         "\"\n",
+                "      export ARTIFACTORY_DBINST=\"",
                 {
                   "Ref": "ArtifactoryDbInst"
                 },
-                "\n",
-                "      export ARTIFACTORY_DBUSER=",
+                "\"\n",
+                "      export ARTIFACTORY_DBUSER=\"",
                 {
                   "Ref": "ArtifactoryDbAdmin"
                 },
-                "\n",
-                "      export ARTIFACTORY_DBPASS=",
+                "\"\n",
+                "      export ARTIFACTORY_DBPASS=\"",
                 {
                   "Ref": "ArtifactoryDbPassword"
                 },
-                "\n",
-                "      export ARTIFACTORY_DBHOST=",
+                "\"\n",
+                "      export ARTIFACTORY_DBHOST=\"",
                 {
                   "Ref": "ArtifactoryDbHost"
                 },
-                "\n",
-                "      export ARTIFACTORY_DBPORT=",
+                "\"\n",
+                "      export ARTIFACTORY_DBPORT=\"",
                 {
                   "Ref": "ArtifactoryDbPort"
                 },
-                "\n",
+                "\"\n",
                 "      \n",
                 "      # For tiered-storage Setup\n",
-                "      export ARTIFACTORY_BUCKET=",
+                "      export ARTIFACTORY_BUCKET=\"",
                 {
                   "Ref": "ArtifactoryArtifactBucket"
                 },
-                "\n",
-                "      export ARTIFACTORY_ROLE=",
+                "\"\n",
+                "      export ARTIFACTORY_ROLE=\"",
                 {
                   "Ref": "InstanceRole"
                 },
-                "\n",
+                "\"\n",
                 "      \n",
                 "      env | grep ARTIFACTORY > /root/AF.envs\n",
                 "      \n",

--- a/Templates/make_artifactory_EC2-node.tmplt.json
+++ b/Templates/make_artifactory_EC2-node.tmplt.json
@@ -37,6 +37,18 @@
         }
       ]
     },
+    "CreateBackupVolume": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "BackupVolumeDevice"
+            },
+            ""
+          ]
+        }
+      ]
+    },
     "Reboot": {
       "Fn::Not": [
         {
@@ -100,13 +112,24 @@
         },
         {
           "Label": {
-            "default": "Instance - Optional Storage"
+            "default": "Instance - (Optional) Artifact Cache"
           },
           "Parameters": [
             "AppVolumeSize",
             "AppVolumeType",
             "AppVolumeDevice",
             "AppVolumeMountPath"
+          ]
+        },
+        {
+          "Label": {
+            "default": "Instance - (Optional) Backup-Staging"
+          },
+          "Parameters": [
+            "BackupVolumeSize",
+            "BackupVolumeType",
+            "BackupVolumeDevice",
+            "BackupVolumeMountPath"
           ]
         },
         {
@@ -243,6 +266,45 @@
     "AmiId": {
       "AllowedPattern": "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$",
       "Description": "ID of the AMI to launch",
+      "Type": "String"
+    },
+    "BackupVolumeDevice": {
+      "AllowedValues": [
+        "",
+        "/dev/xvdk",
+        "/dev/xvdl",
+        "/dev/xvdm",
+        "/dev/xvdn",
+        "/dev/xvdo"
+      ],
+      "Default": "",
+      "Description": "Device to mount an backup-staging location. Leave blank to launch without a backup-staging volume",
+      "Type": "String"
+    },
+    "BackupVolumeMountPath": {
+      "AllowedPattern": "/.*",
+      "Default": "/var/backups",
+      "Description": "Filesystem path to mount the backup-stageing volume. Ignored if \"BackupVolumeDevice\" is blank",
+      "Type": "String"
+    },
+    "BackupVolumeSize": {
+      "ConstraintDescription": "Must be between 1GB and 16384GB.",
+      "Default": "10",
+      "Description": "Size in GB of the EBS volume to create. Ignored if \"BackupVolumeDevice\" is blank",
+      "MaxValue": "16384",
+      "MinValue": "10",
+      "Type": "Number"
+    },
+    "BackupVolumeType": {
+      "AllowedValues": [
+        "gp2",
+        "io1",
+        "sc1",
+        "st1",
+        "standard"
+      ],
+      "Default": "gp2",
+      "Description": "Type of EBS volume to create. Ignored if \"BackupVolumeDevice\" is blank",
       "Type": "String"
     },
     "AppVolumeDevice": {
@@ -678,6 +740,28 @@
                 "Ref": "AWS::NoValue"
               }
             ]
+          },
+          {
+            "Fn::If": [
+              "CreateBackupVolume",
+              {
+                "DeviceName": {
+                  "Ref": "BackupVolumeDevice"
+                },
+                "Ebs": {
+                  "DeleteOnTermination": "true",
+                  "VolumeSize": {
+                    "Ref": "BackupVolumeSize"
+                  },
+                  "VolumeType": {
+                    "Ref": "BackupVolumeType"
+                  }
+                }
+              },
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ]
           }
         ],
         "IamInstanceProfile": {
@@ -785,6 +869,11 @@
                   "Ref": "AppVolumeDevice"
                 },
                 "\n",
+                "  - cloud-init-per instance mkfs-bkupvolume mkfs -t ext4 ",
+                {
+                  "Ref": "BackupVolumeDevice"
+                },
+                "\n",
                 "\n",
                 "mounts:\n",
                 "  - [ ",
@@ -796,6 +885,19 @@
                 "\"",
                 {
                   "Ref": "AppVolumeMountPath"
+                },
+                "\", ",
+                "\"auto\" ",
+                "]\n",
+                "  - [ ",
+                "\"",
+                {
+                  "Ref": "BackupVolumeDevice"
+                },
+                "\", ",
+                "\"",
+                {
+                  "Ref": "BackupVolumeMountPath"
                 },
                 "\", ",
                 "\"auto\" ",
@@ -976,6 +1078,14 @@
                 },
                 " | tee /root/dbsetup.sh | bash || err_exit \"DB-connector ",
                 "script exited abnormally.\"\n",
+                "      \n",
+                "      # Ensure that Artifactory can use backups target\n",
+                "      chown artifactory:artifactory ",
+                {
+                  "Ref": "BackupVolumeMountPath"
+                },
+                " || err_exit \"Failed to set correct ownership",
+                " on the backup-staging filesystem.\"\n",
                 "      \n",
                 "      # Ensure that Artifactory can use CacheFS target\n",
                 "      chown artifactory:artifactory ",

--- a/Templates/make_artifactory_parent.tmplt.json
+++ b/Templates/make_artifactory_parent.tmplt.json
@@ -40,6 +40,7 @@
             "SecurityGroupIds",
             "SubnetIds",
             "ArtifactoryHaBundleUrl",
+            "ArtifactoryIsHaMember",
             "ArtifactoryIsHaPrimary",
             "NoPublicIp",
             "NoReboot"
@@ -153,6 +154,9 @@
         },
         "ArtifactoryHaBundleUrl": {
           "default": "HA config-bundle"
+        },
+        "ArtifactoryIsHaMember": {
+          "default": "Is HA cluster member"
         },
         "ArtifactoryIsHaPrimary": {
           "default": "HA sole/primary node"
@@ -300,6 +304,15 @@
     "ArtifactoryHostTemplate": {
       "AllowedPattern": "^$|^http://.*$|^https://.*$",
       "Description": "URL to the child-template for creating the Artifactory-host EC2 instance.",
+      "Type": "String"
+    },
+    "ArtifactoryIsHaMember": {
+      "Description": "Whether instance is a member of an HA cluster.",
+      "AllowedValues": [
+        "true",
+        "false"
+      ],
+      "Default": "true",
       "Type": "String"
     },
     "ArtifactoryIsHaPrimary": {
@@ -548,6 +561,9 @@
           },
           "ArtifactoryHome": {
             "Ref": "ArtifactoryHome"
+          },
+          "ArtifactoryIsHaMember": {
+            "Ref": "ArtifactoryIsHaMember"
           },
           "ArtifactoryIsHaPrimary": {
             "Ref": "ArtifactoryIsHaPrimary"

--- a/Templates/make_artifactory_parent.tmplt.json
+++ b/Templates/make_artifactory_parent.tmplt.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "This template coordinates the running of the Artifactory S3 and IAM templates.",
+  "Description": "This template coordinates the running of the Artifactory S3, IAM and EC2 templates.",
   "Metadata": {
     "AWS::CloudFormation::Interface": {
       "ParameterGroups": [
@@ -21,7 +21,8 @@
           "Parameters": [
             "ArtifactoryOsPrepScriptUrl",
             "ArtifactoryDbPropsScriptUrl",
-            "ArtifactoryStorageScriptUrl"
+            "ArtifactoryStorageScriptUrl",
+            "ArtifactoryHaSetupScriptUrl"
           ]
         },
         {
@@ -38,19 +39,32 @@
             "Domainname",
             "SecurityGroupIds",
             "SubnetIds",
+            "ArtifactoryHaBundleUrl",
+            "ArtifactoryIsHaPrimary",
             "NoPublicIp",
             "NoReboot"
           ]
         },
         {
           "Label": {
-            "default": "Instance - Optional Storage"
+            "default": "Instance - (Optional) Artifact Cache"
           },
           "Parameters": [
             "AppVolumeSize",
             "AppVolumeType",
             "AppVolumeDevice",
             "AppVolumeMountPath"
+          ]
+        },
+        {
+          "Label": {
+            "default": "Instance - (Optional) Backup-Staging"
+          },
+          "Parameters": [
+            "BackupVolumeSize",
+            "BackupVolumeType",
+            "BackupVolumeDevice",
+            "BackupVolumeMountPath"
           ]
         },
         {
@@ -119,6 +133,9 @@
         "ArtifactoryDbPropsScriptUrl": {
           "default": "DB target-script URL"
         },
+        "ArtifactoryHaSetupScriptUrl": {
+          "default": "HA setup-script URL"
+        },
         "ArtifactoryHome": {
           "default": "${ARTIFACTORY_HOME}"
         },
@@ -133,6 +150,12 @@
         },
         "ArtifactoryStorageScriptUrl": {
           "default": "Storage script URL"
+        },
+        "ArtifactoryHaBundleUrl": {
+          "default": "HA config-bundle"
+        },
+        "ArtifactoryIsHaPrimary": {
+          "default": "HA sole/primary node"
         },
         "CfnEndpointUrl": {
           "default": "Cloudformation Endpoint"
@@ -258,6 +281,16 @@
       "Description": "URL to script that performs DB-client configuration actions for Artifactory",
       "Type": "String"
     },
+    "ArtifactoryHaBundleUrl": {
+      "AllowedPattern": "^$|^http://.*$|^https://.*$",
+      "Description": "Url of Artifactory HA node bundle file.",
+      "Type": "String"
+    },
+    "ArtifactoryHaSetupScriptUrl": {
+      "AllowedPattern": "^$|^http://.*$|^https://.*$",
+      "Description": "URL to script that performs HA cluster configuration.",
+      "Type": "String"
+    },
     "ArtifactoryHome": {
       "ConstraintDescription": "An LSB-compliant, slash-delimited directory-path.",
       "Default": "/var/opt/jfrog/artifactory",
@@ -267,6 +300,15 @@
     "ArtifactoryHostTemplate": {
       "AllowedPattern": "^$|^http://.*$|^https://.*$",
       "Description": "URL to the child-template for creating the Artifactory-host EC2 instance.",
+      "Type": "String"
+    },
+    "ArtifactoryIsHaPrimary": {
+      "AllowedValues": [
+        "true",
+        "false"
+      ],
+      "Default": "true",
+      "Description": "Whether instance is primary node in an HA cluster.",
       "Type": "String"
     },
     "ArtifactoryLicenseUrl": {
@@ -287,6 +329,45 @@
     "ArtifactoryStorageScriptUrl": {
       "AllowedPattern": "^$|^http://.*$|^https://.*$",
       "Description": "URL to script that performs tiered-storage configuration actions for Artifactory",
+      "Type": "String"
+    },
+    "BackupVolumeDevice": {
+      "AllowedValues": [
+        "",
+        "/dev/xvdk",
+        "/dev/xvdl",
+        "/dev/xvdm",
+        "/dev/xvdn",
+        "/dev/xvdo"
+      ],
+      "Default": "",
+      "Description": "Device to mount an backup-staging location. Leave blank to launch without a backup-staging volume",
+      "Type": "String"
+    },
+    "BackupVolumeMountPath": {
+      "AllowedPattern": "/.*",
+      "Default": "/var/backups",
+      "Description": "Filesystem path to mount the backup-stageing volume. Ignored if \"BackupVolumeDevice\" is blank",
+      "Type": "String"
+    },
+    "BackupVolumeSize": {
+      "ConstraintDescription": "Must be between 1GB and 16384GB.",
+      "Default": "10",
+      "Description": "Size in GB of the EBS volume to create. Ignored if \"BackupVolumeDevice\" is blank",
+      "MaxValue": "16384",
+      "MinValue": "10",
+      "Type": "Number"
+    },
+    "BackupVolumeType": {
+      "AllowedValues": [
+        "gp2",
+        "io1",
+        "sc1",
+        "st1",
+        "standard"
+      ],
+      "Default": "gp2",
+      "Description": "Type of EBS volume to create. Ignored if \"BackupVolumeDevice\" is blank",
       "Type": "String"
     },
     "BucketIamTemplate": {
@@ -459,8 +540,17 @@
           "ArtifactoryDbPropsScriptUrl": {
             "Ref": "ArtifactoryDbPropsScriptUrl"
           },
+          "ArtifactoryHaBundleUrl": {
+            "Ref": "ArtifactoryHaBundleUrl"
+          },
+          "ArtifactoryHaSetupScriptUrl": {
+            "Ref": "ArtifactoryHaSetupScriptUrl"
+          },
           "ArtifactoryHome": {
             "Ref": "ArtifactoryHome"
+          },
+          "ArtifactoryIsHaPrimary": {
+            "Ref": "ArtifactoryIsHaPrimary"
           },
           "ArtifactoryLicenseUrl": {
             "Ref": "ArtifactoryLicenseUrl"
@@ -473,6 +563,18 @@
           },
           "ArtifactoryStorageScriptUrl": {
             "Ref": "ArtifactoryStorageScriptUrl"
+          },
+          "BackupVolumeDevice": {
+            "Ref": "BackupVolumeDevice"
+          },
+          "BackupVolumeMountPath": {
+            "Ref": "BackupVolumeMountPath"
+          },
+          "BackupVolumeSize": {
+            "Ref": "BackupVolumeSize"
+          },
+          "BackupVolumeType": {
+            "Ref": "BackupVolumeType"
           },
           "CfnEndpointUrl": {
             "Ref": "CfnEndpointUrl"
@@ -531,7 +633,9 @@
           "SecurityGroupIds": {
             "Fn::Join": [
               ",",
-              { "Ref": "SecurityGroupIds" }
+              {
+                "Ref": "SecurityGroupIds"
+              }
             ]
           },
           "SubnetIds": {


### PR DESCRIPTION
Update makes the EC2 child template usable for both an initial, linked-stack deployment and for a re-deployment of a single-node HA config.